### PR TITLE
Added preliminary support for MPU6886 as an overlay over current MPU6…

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ See `mgos_imu.h` for more details and an example of how to do this.
 *   LSM9DS1
 *   LSM6DSL
 *   MPU6000 and MPU6050
+*   MPU6886 ("just works")
 *   ICM20948
 
 ### Gyroscope
@@ -117,6 +118,7 @@ See `mgos_imu.h` for more details and an example of how to do this.
 *   LSM9DS1
 *   LSM6DSL
 *   MPU6000 and MPU6050
+*   MPU6886 (work in progress)
 *   ICM20948
 
 ### Magnetometer

--- a/include/mgos_imu.h
+++ b/include/mgos_imu.h
@@ -48,6 +48,7 @@ enum mgos_imu_acc_type {
   ACC_LSM6DSL,
   ACC_MPU6000,
   ACC_MPU6050,
+  ACC_MPU6886,
   ACC_ICM20948
 };
 
@@ -62,6 +63,7 @@ enum mgos_imu_gyro_type {
   GYRO_LSM6DSL,
   GYRO_MPU6000,
   GYRO_MPU6050,
+  GYRO_MPU6886,
   GYRO_ICM20948
 };
 

--- a/src/mgos_imu_accelerometer.c
+++ b/src/mgos_imu_accelerometer.c
@@ -23,6 +23,7 @@
 #include "mgos_imu_lsm9ds1.h"
 #include "mgos_imu_lsm6dsl.h"
 #include "mgos_imu_mpu60x0.h"
+#include "mgos_imu_mpu6886.h"
 #include "mgos_imu_icm20948.h"
 
 static struct mgos_imu_acc *mgos_imu_acc_create(void) {
@@ -92,6 +93,8 @@ const char *mgos_imu_accelerometer_get_name(struct mgos_imu *imu) {
 
   case ACC_MPU6050: return "MPU6050";
 
+  case ACC_MPU6886: return "MPU6886";
+
   case ACC_ICM20948: return "ICM20948";
 
   default: return "UNKNOWN";
@@ -138,6 +141,17 @@ bool mgos_imu_accelerometer_create_i2c(struct mgos_imu *imu, struct mgos_i2c *i2
   case ACC_MPU6000:
   case ACC_MPU6050:
     imu->acc->detect    = mgos_imu_mpu60x0_acc_detect;
+    imu->acc->create    = mgos_imu_mpu60x0_acc_create;
+    imu->acc->read      = mgos_imu_mpu60x0_acc_read;
+    imu->acc->get_scale = mgos_imu_mpu60x0_acc_get_scale;
+    imu->acc->set_scale = mgos_imu_mpu60x0_acc_set_scale;
+    if (!imu->user_data) {
+      imu->user_data = mgos_imu_mpu60x0_userdata_create();
+    }
+    break;
+
+  case ACC_MPU6886:
+    imu->acc->detect    = mgos_imu_mpu6886_acc_detect;
     imu->acc->create    = mgos_imu_mpu60x0_acc_create;
     imu->acc->read      = mgos_imu_mpu60x0_acc_read;
     imu->acc->get_scale = mgos_imu_mpu60x0_acc_get_scale;

--- a/src/mgos_imu_gyroscope.c
+++ b/src/mgos_imu_gyroscope.c
@@ -22,6 +22,7 @@
 #include "mgos_imu_lsm9ds1.h"
 #include "mgos_imu_lsm6dsl.h"
 #include "mgos_imu_mpu60x0.h"
+#include "mgos_imu_mpu6886.h"
 #include "mgos_imu_icm20948.h"
 
 static struct mgos_imu_gyro *mgos_imu_gyro_create(void) {
@@ -98,6 +99,8 @@ const char *mgos_imu_gyroscope_get_name(struct mgos_imu *imu) {
 
   case GYRO_MPU6050: return "MPU6050";
 
+  case GYRO_MPU6886: return "MPU6886";
+
   case GYRO_ICM20948: return "ICM20948";
 
   default: return "UNKNOWN";
@@ -150,6 +153,17 @@ bool mgos_imu_gyroscope_create_i2c(struct mgos_imu *imu, struct mgos_i2c *i2c, u
   case GYRO_MPU6000:
   case GYRO_MPU6050:
     imu->gyro->detect    = mgos_imu_mpu60x0_gyro_detect;
+    imu->gyro->create    = mgos_imu_mpu60x0_gyro_create;
+    imu->gyro->read      = mgos_imu_mpu60x0_gyro_read;
+    imu->gyro->get_scale = mgos_imu_mpu60x0_gyro_get_scale;
+    imu->gyro->set_scale = mgos_imu_mpu60x0_gyro_set_scale;
+    if (!imu->user_data) {
+      imu->user_data = mgos_imu_mpu60x0_userdata_create();
+    }
+    break;
+
+  case GYRO_MPU6886:
+    imu->gyro->detect    = mgos_imu_mpu6886_gyro_detect;
     imu->gyro->create    = mgos_imu_mpu60x0_gyro_create;
     imu->gyro->read      = mgos_imu_mpu60x0_gyro_read;
     imu->gyro->get_scale = mgos_imu_mpu60x0_gyro_get_scale;

--- a/src/mgos_imu_mpu6886.c
+++ b/src/mgos_imu_mpu6886.c
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2020 Sergio R. Caprile and Cika Electronica S.R.L.
+ * All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the ""License"");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an ""AS IS"" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "mgos_imu_mpu6886.h"
 #include "mgos.h"
 #include "mgos_i2c.h"

--- a/src/mgos_imu_mpu6886.c
+++ b/src/mgos_imu_mpu6886.c
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "mgos_imu_mpu6886.h"
+#include "mgos_imu_mpu60x0.h"
+#include "mgos.h"
+#include "mgos_i2c.h"
+
+static bool mgos_imu_mpu6886_detect(struct mgos_i2c *i2c, uint8_t i2caddr) {
+  if (!i2c) {
+    return false;
+  }
+
+  return MGOS_MPU6886_DEVID ==
+         mgos_i2c_read_reg_b(i2c, i2caddr, MGOS_MPU60X0_REG_WHO_AM_I);
+}
+
+bool mgos_imu_mpu6886_acc_detect(struct mgos_imu_acc *dev,
+                                 void *imu_user_data) {
+  return mgos_imu_mpu6886_detect(dev->i2c, dev->i2caddr);
+
+  (void)imu_user_data;
+}
+
+bool mgos_imu_mpu6886_gyro_detect(struct mgos_imu_gyro *dev,
+                                  void *imu_user_data) {
+  return mgos_imu_mpu6886_detect(dev->i2c, dev->i2caddr);
+
+  (void)imu_user_data;
+}

--- a/src/mgos_imu_mpu6886.c
+++ b/src/mgos_imu_mpu6886.c
@@ -1,31 +1,20 @@
-/*
- * Copyright 2018 Google Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 #include "mgos_imu_mpu6886.h"
-#include "mgos_imu_mpu60x0.h"
 #include "mgos.h"
 #include "mgos_i2c.h"
+#include "mgos_imu_mpu60x0.h"
 
 static bool mgos_imu_mpu6886_detect(struct mgos_i2c *i2c, uint8_t i2caddr) {
   if (!i2c) {
     return false;
   }
 
-  return MGOS_MPU6886_DEVID ==
-         mgos_i2c_read_reg_b(i2c, i2caddr, MGOS_MPU60X0_REG_WHO_AM_I);
+  if (MGOS_MPU6886_DEVID !=
+      mgos_i2c_read_reg_b(i2c, i2caddr, MGOS_MPU60X0_REG_WHO_AM_I)) {
+    return false;
+  }
+  LOG(LL_WARN, ("This driver is experimental and work in progress. Proceed "
+                "with caution!"));
+  return true;
 }
 
 bool mgos_imu_mpu6886_acc_detect(struct mgos_imu_acc *dev,

--- a/src/mgos_imu_mpu6886.h
+++ b/src/mgos_imu_mpu6886.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "mgos.h"
+#include "mgos_imu_internal.h"
+
+#define MGOS_MPU6886_DEFAULT_I2CADDR         (0x68)
+#define MGOS_MPU6886_DEVID                   (0x19)
+
+#define MGOS_MPU6886_GYRO_OFFSET             (0x13)
+#define MGOS_MPU6886_ACCEL_CONFIG2           (0x1D)
+#define MGOS_MPU6886_ACCEL_INTEL_CTRL        (0x69)
+
+
+bool mgos_imu_mpu6886_acc_detect(struct mgos_imu_acc *dev, void *imu_user_data);
+
+bool mgos_imu_mpu6886_gyro_detect(struct mgos_imu_gyro *dev,
+                                  void *imu_user_data);

--- a/src/mgos_imu_mpu6886.h
+++ b/src/mgos_imu_mpu6886.h
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2020 Sergio R. Caprile and Cika Electronica S.R.L.
+ * All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the ""License"");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an ""AS IS"" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #pragma once
 
 #include "mgos.h"

--- a/src/mgos_imu_mpu6886.h
+++ b/src/mgos_imu_mpu6886.h
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 Google Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 #pragma once
 
 #include "mgos.h"


### PR DESCRIPTION
Hi, been toying with the IMU in the M5Stack and modified the IMU library to add basic support to the MPU6886 (just added the whoami, the rest is handled as is by the current MPU60x0 driver).
The accelerometer just works. Reads ‘g’ in the proper direction… noise seems to be at 1%g
The gyroscope has a permanent offset, in the order of 10, and seems to be very noisy, in the order of 1.
All those numbers read at the IMU demo application console.
I slightly modified that demo to send the proper calibration and reset quaternion commands to the ESP32. The results are quite unstable, the device starts to roll a couple degrees quickly after calibration. Perhaps something more needs to be done at the driver level. I’m NIL at this.
